### PR TITLE
fix(ci): correct Helm image tag rewrite for prerelease versions

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -148,7 +148,8 @@ jobs:
         run: |
           sed -i "s/^version:.*/version: $VERSION/" helm/crossview/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"$TAG\"/" helm/crossview/Chart.yaml
-          sed -i "s|ghcr.io/crossplane-contrib/crossview:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/crossplane-contrib/crossview:$TAG|" helm/crossview/Chart.yaml
+          # Replace the full image tag (including pre-release suffixes) to avoid malformed tags like "...-rc.7-rc.4".
+          sed -E -i "s|(image:[[:space:]]*ghcr.io/crossplane-contrib/crossview:)v[^[:space:]]+|\\1$TAG|" helm/crossview/Chart.yaml
           echo "Updated Chart.yaml to version $VERSION (appVersion: $TAG):"
           cat helm/crossview/Chart.yaml
 

--- a/helm/crossview/Chart.yaml
+++ b/helm/crossview/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
 annotations:
   artifacthub.io/images: |
     - name: crossview
-      image: ghcr.io/crossplane-contrib/crossview:v3.6.0-rc.7
+      image: ghcr.io/crossplane-contrib/crossview:v3.9.0-rc.4
     - name: postgres
       image: postgres:latest
 dependencies: []


### PR DESCRIPTION
- Updated the replacement command in `helm-release.yml:151`  to replace the full existing tag (including pre-release suffixes), not just vX.Y.Z.

- Corrected the current stale Artifact Hub image annotation in `Chart.yaml:21` so it matches current appVersion.