### PR TITLE
feat(helm): add Gateway API HTTPRoute support

### DIFF
--- a/helm/crossview/README.md
+++ b/helm/crossview/README.md
@@ -185,6 +185,34 @@ helm install crossview ./helm/crossview \
   --set ingress.tls[0].hosts[0]=crossview.example.com
 ```
 
+## Gateway API Configuration
+
+As an alternative to Ingress, the chart can render an `HTTPRoute` (Gateway API)
+that attaches to an existing `Gateway`. This requires the Gateway API CRDs and a
+Gateway controller already installed in the cluster.
+
+```bash
+helm install crossview ./helm/crossview \
+  --namespace crossview \
+  --create-namespace \
+  --set gatewayAPI.enabled=true \
+  --set gatewayAPI.httpRoute.parentRefs[0].name=my-gateway \
+  --set gatewayAPI.httpRoute.parentRefs[0].namespace=gateway-system \
+  --set gatewayAPI.httpRoute.hostnames[0]=crossview.example.com
+```
+
+Key `gatewayAPI.httpRoute` values:
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` | HTTPRoute apiVersion (default `gateway.networking.k8s.io/v1`; set `gateway.networking.k8s.io/v1beta1` for older controllers) |
+| `parentRefs` | List of Gateways to attach to. `name` is required; `namespace`, `sectionName`, `port`, `group`, `kind` are optional |
+| `hostnames` | Hostnames the route matches. Omit/empty to match all hostnames on the Gateway |
+| `rules` | Routing rules. Each rule may override `matches`, `filters`, `backendRefs` and `timeouts`. Default: a single `PathPrefix` `/` match routed to the crossview service |
+| `annotations` / `labels` | Extra metadata on the HTTPRoute |
+
+Enable only one of `ingress` or `gatewayAPI` at a time.
+
 ## Important Notes
 
 - When `config.server.auth.mode` = `session` → `secrets.dbPassword` and `secrets.sessionSecret` are required

--- a/helm/crossview/templates/NOTES.txt
+++ b/helm/crossview/templates/NOTES.txt
@@ -5,6 +5,11 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.gatewayAPI.enabled }}
+{{- range $hostname := .Values.gatewayAPI.httpRoute.hostnames }}
+  http://{{ $hostname }}/
+{{- end }}
+  NOTE: traffic is served through the Gateway referenced in gatewayAPI.httpRoute.parentRefs.
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "crossview.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/helm/crossview/templates/httproute.yaml
+++ b/helm/crossview/templates/httproute.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.httpRoute -}}
+apiVersion: {{ .Values.gatewayAPI.httpRoute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "crossview.fullname" . }}-httproute
+  namespace: {{ include "crossview.namespace" . }}
+  labels:
+    {{- include "crossview.labels" . | nindent 4 }}
+    {{- with .Values.gatewayAPI.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.gatewayAPI.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+      {{- with .group }}
+      group: {{ . }}
+      {{- end }}
+      {{- with .kind }}
+      kind: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gatewayAPI.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $rule := .Values.gatewayAPI.httpRoute.rules }}
+    - matches:
+        {{- if $rule.matches }}
+        {{- toYaml $rule.matches | nindent 8 }}
+        {{- else }}
+        - path:
+            type: PathPrefix
+            value: /
+        {{- end }}
+      {{- with $rule.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- if $rule.backendRefs }}
+        {{- toYaml $rule.backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ include "crossview.fullname" $ }}-service
+          port: {{ $.Values.service.port }}
+          weight: 1
+        {{- end }}
+      {{- with $rule.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "crossview.fullname" . }}-service
+          port: {{ .Values.service.port }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/helm/crossview/tests/httproute_test.yaml
+++ b/helm/crossview/tests/httproute_test.yaml
@@ -1,0 +1,75 @@
+suite: test Gateway API HTTPRoute
+templates:
+  - httproute.yaml
+tests:
+  - it: should render nothing when gatewayAPI is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when gatewayAPI is enabled
+    set:
+      gatewayAPI:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-crossview-httproute
+
+  - it: should attach to the configured parentRefs and hostnames
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          parentRefs:
+            - name: my-gateway
+              namespace: gateway-system
+              sectionName: https
+          hostnames:
+            - crossview.example.com
+    asserts:
+      - equal:
+          path: spec.parentRefs[0]
+          value:
+            name: my-gateway
+            namespace: gateway-system
+            sectionName: https
+      - equal:
+          path: spec.hostnames[0]
+          value: crossview.example.com
+
+  - it: should default a PathPrefix rule to the crossview service
+    set:
+      gatewayAPI:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-crossview-service
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should honor an overridden apiVersion
+    set:
+      gatewayAPI:
+        enabled: true
+        httpRoute:
+          apiVersion: gateway.networking.k8s.io/v1beta1
+    asserts:
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1beta1

--- a/helm/crossview/values.schema.json
+++ b/helm/crossview/values.schema.json
@@ -125,6 +125,38 @@
         "tls": { "type": "array" }
       }
     },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API support. Renders an HTTPRoute attached to an existing Gateway.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "httpRoute": {
+          "type": "object",
+          "properties": {
+            "apiVersion": { "type": "string", "default": "gateway.networking.k8s.io/v1" },
+            "annotations": { "type": "object" },
+            "labels": { "type": "object" },
+            "parentRefs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "namespace": { "type": "string" },
+                  "sectionName": { "type": "string" },
+                  "port": { "type": "integer" },
+                  "group": { "type": "string" },
+                  "kind": { "type": "string" }
+                },
+                "required": ["name"]
+              }
+            },
+            "hostnames": { "type": "array", "items": { "type": "string" } },
+            "rules": { "type": "array" }
+          }
+        }
+      }
+    },
     "database": {
       "type": "object",
       "properties": {

--- a/helm/crossview/values.yaml
+++ b/helm/crossview/values.yaml
@@ -95,6 +95,33 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Gateway API configuration (alternative to ingress)
+# Requires the Gateway API CRDs and a Gateway controller installed in the cluster.
+# The chart renders an HTTPRoute that attaches to an existing Gateway via parentRefs.
+gatewayAPI:
+  enabled: false
+  httpRoute:
+    # apiVersion of the HTTPRoute resource. Override for older controllers (e.g. v1beta1).
+    apiVersion: gateway.networking.k8s.io/v1
+    annotations: {}
+    labels: {}
+    # Gateway(s) this route attaches to. name is required; the rest are optional.
+    parentRefs:
+      - name: gateway
+        # namespace: gateway-system
+        # sectionName: https
+        # port: 443
+    # Hostnames this route matches. Leave empty to match all hostnames on the Gateway.
+    hostnames:
+      - crossview.example.com
+    # Routing rules. Each rule may override matches, filters, backendRefs and timeouts.
+    # Defaults: a single PathPrefix "/" match routed to the crossview service.
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /
+
 # Database configuration
 database:
   enabled: true


### PR DESCRIPTION
Adds a `gatewayAPI` section to the chart mirroring `ingress`. When `gatewayAPI.enabled` is set, the chart renders an HTTPRoute attached to an existing Gateway via `parentRefs`, defaulting the backend to the crossview service on `service.port`. Each rule can override matches, filters, backendRefs and timeouts.

- new template templates/httproute.yaml
- gatewayAPI schema in values.schema.json
- NOTES.txt prints the hostname URL when gatewayAPI is enabled
- README "Gateway API Configuration" section
- helm-unittest suite tests/httproute_test.yaml

Relates to #298